### PR TITLE
fix example code indentation

### DIFF
--- a/_includes/translation/rus/06_the-module-pattern.md
+++ b/_includes/translation/rus/06_the-module-pattern.md
@@ -87,22 +87,22 @@ Dojo старается обеспечивать поведение похоже
 
 {% highlight javascript %}
 
-    // традиционный способ
-    var store = window.store || {};
-    store.basket = store.basket || {};
-    
-    // с помощью dojo.setObject
-    dojo.setObject("store.basket.object", (function() {
-        var basket = [];
-        function privateMethod() {
-            console.log(basket);
+// традиционный способ
+var store = window.store || {};
+store.basket = store.basket || {};
+
+// с помощью dojo.setObject
+dojo.setObject("store.basket.object", (function() {
+    var basket = [];
+    function privateMethod() {
+        console.log(basket);
+    }
+    return {
+        publicMethod: function() {
+            privateMethod();
         }
-        return {
-            publicMethod: function() {
-                privateMethod();
-            }
-        };
-    }()));
+    };
+}()));
 
 {% endhighlight %}
 
@@ -117,32 +117,32 @@ Dojo старается обеспечивать поведение похоже
 
 {% highlight javascript %}
 
-    YAHOO.store.basket = function () {
-    
-        // приватная переменная:
-        var myPrivateVar = "Ко мне можно получить доступ только из YAHOO.store.basket.";
-        
-        // приватный метод:
-        var myPrivateMethod = function() {
-            YAHOO.log("Я доступен только при вызове из YAHOO.store.basket");
+YAHOO.store.basket = function () {
+
+    // приватная переменная:
+    var myPrivateVar = "Ко мне можно получить доступ только из YAHOO.store.basket.";
+
+    // приватный метод:
+    var myPrivateMethod = function() {
+        YAHOO.log("Я доступен только при вызове из YAHOO.store.basket");
+    }
+
+    return {
+        myPublicProperty: "Я - публичное свойство",
+        myPublicMethod: function() {
+            YAHOO.log("Я - публичный метод");
+
+            // Будучи внутри корзины я могу получить доступ к приватным переменный и методам:
+            YAHOO.log(myPrivateVar);
+            YAHOO.log(myPrivateMethod());
+
+            // Родной контекст метода myPublicMethod сохранён
+            // поэтому мы имеет доступ к this
+            YAHOO.log(this.myPublicProperty);
         }
-        
-        return {
-            myPublicProperty: "Я - публичное свойство",
-            myPublicMethod: function() {
-                YAHOO.log("Я - публичный метод");
-        
-                // Будучи внутри корзины я могу получить доступ к приватным переменный и методам:
-                YAHOO.log(myPrivateVar);
-                YAHOO.log(myPrivateMethod());
-        
-                // Родной контекст метода myPublicMethod сохранён
-                // поэтому мы имеет доступ к this
-                YAHOO.log(this.myPublicProperty);
-            }
-        };
-        
-    }();
+    };
+
+}();
 
 {% endhighlight %}
 
@@ -160,22 +160,22 @@ Dojo старается обеспечивать поведение похоже
 
 {% highlight javascript %}
 
-    function library(module) {
-      $(function() {
-        if (module.init) {
-          module.init();
-        }
-      });
-      return module;
+function library(module) {
+  $(function() {
+    if (module.init) {
+      module.init();
     }
-    
-    var myLibrary = library(function() {
-       return {
-         init: function() {
-           /* код модуля */
-         }
-       };
-    }());
+  });
+  return module;
+}
+
+var myLibrary = library(function() {
+   return {
+     init: function() {
+       /* код модуля */
+     }
+   };
+}());
 
 {% endhighlight %}
 


### PR DESCRIPTION
Previously first line was aligned to the left on the result page
(http://largescalejs.ru/module-pattern/).
